### PR TITLE
[CRITICAL] Fix hardcoded credentials vulnerability in TrueNAS MCP

### DIFF
--- a/truenas-mcp/README.md
+++ b/truenas-mcp/README.md
@@ -78,6 +78,8 @@ A **portable, HTTP-based** Model Context Protocol (MCP) server that provides an 
    TRUENAS_HOST=your-truenas-host.example.com
    TRUENAS_API_KEY=your-api-key-here
    SECRET_KEY=your-generated-secret-key
+   ADMIN_USERNAME=your-admin-username
+   ADMIN_PASSWORD=your-secure-admin-password
    ```
 
 4. **Start server**:
@@ -130,10 +132,13 @@ kubectl create secret generic truenas-mcp-secrets \
 | `TRUENAS_USERNAME` | Username for authentication | - | Yes* |
 | `TRUENAS_PASSWORD` | Password for authentication | - | Yes* |
 | `SECRET_KEY` | JWT secret key | - | Yes |
+| `ADMIN_USERNAME` | MCP admin username for JWT auth | - | Yes** |
+| `ADMIN_PASSWORD` | MCP admin password for JWT auth | - | Yes** |
 | `SERVER_PORT` | MCP server port | 8000 | No |
 | `DEBUG` | Enable debug mode | false | No |
 
-*Either API key or username/password is required.
+*Either API key or username/password is required for TrueNAS authentication.
+**Required for JWT authentication. Used to create the MCP admin user.
 
 ### Using the CLI
 
@@ -178,9 +183,9 @@ Create a JSON configuration file:
 
 2. **Get a JWT token**:
    ```bash
-   # Login with default credentials
+   # Login (you will be prompted for username and password)
    python -m src.http_cli login
-   
+
    # Or create token with admin token
    python -m src.http_cli create-token --admin-token your-admin-token
    ```
@@ -338,7 +343,9 @@ result = await call_tool("truenas_storage_create_dataset", {
 
 ## Security Considerations
 
+- **Credential Management**: All credentials must be provided via environment variables. No default or hardcoded credentials exist
 - **API Key Management**: Store API keys securely and rotate them regularly
+- **Admin Credentials**: Set strong, unique values for `ADMIN_USERNAME` and `ADMIN_PASSWORD` in your `.env` file
 - **SSL Verification**: Always verify SSL certificates in production
 - **Input Validation**: All inputs are validated and sanitized
 - **Audit Logging**: All operations are logged for security auditing

--- a/truenas-mcp/env.example
+++ b/truenas-mcp/env.example
@@ -22,6 +22,12 @@ JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 ADMIN_TOKEN=your-admin-token-here
 
+# MCP Admin User Credentials (Required for JWT authentication)
+# These credentials are used to create the initial admin user
+# SECURITY: Use strong passwords and keep these values secret
+ADMIN_USERNAME=your-admin-username
+ADMIN_PASSWORD=your-secure-admin-password
+
 # Logging Configuration
 LOG_LEVEL=INFO
 LOG_FORMAT=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/truenas-mcp/src/auth.py
+++ b/truenas-mcp/src/auth.py
@@ -320,16 +320,32 @@ class JWTAuthManager:
         self._create_default_users()
     
     def _create_default_users(self) -> None:
-        """Create default users for development."""
-        # Create a default admin user
+        """Create admin user from environment variables.
+
+        Requires ADMIN_USERNAME and ADMIN_PASSWORD environment variables to be set.
+        This removes the security risk of hardcoded credentials.
+        """
+        admin_username = os.environ.get("ADMIN_USERNAME")
+        admin_password = os.environ.get("ADMIN_PASSWORD")
+
+        if not admin_username or not admin_password:
+            logger.warning(
+                "ADMIN_USERNAME and ADMIN_PASSWORD environment variables not set. "
+                "No default admin user will be created. "
+                "JWT authentication will require creating users programmatically or via API."
+            )
+            return
+
+        # Create admin user from environment variables
         admin_user = UserInDB(
-            username="admin",
-            email="admin@truenas-mcp.local",
+            username=admin_username,
+            email=f"{admin_username}@truenas-mcp.local",
             full_name="Administrator",
             disabled=False,
-            hashed_password=pwd_context.hash("admin123")  # TODO: Change in production!
+            hashed_password=pwd_context.hash(admin_password)
         )
         self.users_db[admin_user.username] = admin_user
+        logger.info(f"Created admin user: {admin_username}")
     
     def verify_password(self, plain_password: str, hashed_password: str) -> bool:
         """Verify a password against its hash.

--- a/truenas-mcp/src/http_cli.py
+++ b/truenas-mcp/src/http_cli.py
@@ -146,8 +146,8 @@ def health(url: str):
 
 @cli.command()
 @click.option("--url", default="http://localhost:8000", help="Server URL")
-@click.option("--username", default="admin", help="Username")
-@click.option("--password", default="admin123", help="Password (change default in production)")
+@click.option("--username", prompt=True, help="Username")
+@click.option("--password", prompt=True, hide_input=True, help="Password")
 def login(url: str, username: str, password: str):
     """Login to get an access token."""
     try:

--- a/truenas-mcp/tests/test_http_server.py
+++ b/truenas-mcp/tests/test_http_server.py
@@ -7,10 +7,8 @@ from fastapi.testclient import TestClient
 
 # Test configuration constants
 TEST_SECRET_KEY = 'test-secret-key-minimum-32-characters-long-for-security-purposes'
-TEST_ADMIN_USER = 'admin'
-# Note: This matches the default password created by JWTAuthManager._create_default_users()
-# for testing purposes only. In production, change this password immediately.
-TEST_ADMIN_PASS = 'admin123'
+TEST_ADMIN_USER = 'test_admin'
+TEST_ADMIN_PASS = 'test_secure_password_123'
 
 
 class TestHTTPServerImports:
@@ -44,7 +42,9 @@ class TestHTTPServerCreation:
         with patch.dict(os.environ, {
             'TRUENAS_HOST': 'test.example.com',
             'TRUENAS_API_KEY': 'test-api-key',
-            'SECRET_KEY': TEST_SECRET_KEY
+            'SECRET_KEY': TEST_SECRET_KEY,
+            'ADMIN_USERNAME': TEST_ADMIN_USER,
+            'ADMIN_PASSWORD': TEST_ADMIN_PASS
         }):
             yield
     
@@ -90,7 +90,9 @@ class TestHTTPServerEndpoints:
         with patch.dict(os.environ, {
             'TRUENAS_HOST': 'test.example.com',
             'TRUENAS_API_KEY': 'test-api-key',
-            'SECRET_KEY': TEST_SECRET_KEY
+            'SECRET_KEY': TEST_SECRET_KEY,
+            'ADMIN_USERNAME': TEST_ADMIN_USER,
+            'ADMIN_PASSWORD': TEST_ADMIN_PASS
         }):
             from src.http_server import create_app
             app = create_app()
@@ -167,7 +169,9 @@ class TestHTTPServerAuthentication:
             'TRUENAS_HOST': 'test.example.com',
             'TRUENAS_API_KEY': 'test-api-key',
             'SECRET_KEY': TEST_SECRET_KEY,
-            'ADMIN_TOKEN': 'test-admin-token'
+            'ADMIN_TOKEN': 'test-admin-token',
+            'ADMIN_USERNAME': TEST_ADMIN_USER,
+            'ADMIN_PASSWORD': TEST_ADMIN_PASS
         }):
             from src.http_server import create_app
             app = create_app()


### PR DESCRIPTION
## Summary

This PR addresses **Issue #25** - a **CRITICAL** security vulnerability where hardcoded default credentials were present in the TrueNAS MCP codebase.

## Changes Made

### Security Fixes

1. **Removed hardcoded admin credentials** from `src/auth.py:322-332`
   - Replaced hardcoded `admin/admin123` with environment variable requirements
   - Added `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variable support
   - System now only creates admin user if environment variables are set

2. **Fixed CLI password defaults** in `src/http_cli.py:150`
   - Removed default password `admin123` from login command
   - Changed to secure prompt-based credential input
   - Password input is now hidden during entry

3. **Updated configuration examples**
   - Added `ADMIN_USERNAME` and `ADMIN_PASSWORD` to `env.example`
   - Included clear security warnings in configuration documentation

4. **Updated documentation**
   - README.md now includes admin credential requirements
   - Added security note about credential management
   - Updated environment variables table

5. **Fixed test suite**
   - Updated test credentials to use environment variables
   - Removed dependency on hardcoded credentials
   - All tests now use secure test-specific credentials

## Security Impact

**Before:**
- Default admin user with password `admin123` was hardcoded in the codebase
- CLI exposed default credentials in help text
- Anyone could access systems using default credentials

**After:**
- No default or hardcoded credentials exist in codebase
- Admin credentials must be explicitly configured via environment variables
- CLI prompts securely for credentials with hidden input
- Clear warnings if credentials are not configured

## Testing

- ✅ Python syntax validation passed
- ✅ All hardcoded credentials removed (grep verification)
- ✅ Test suite updated to use environment variables
- ✅ Documentation updated and verified

## Closes

Closes #25

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)